### PR TITLE
Don't send asleep message if no one is sleeping

### DIFF
--- a/src/main/java/com/extracraftx/minecraft/bettersleeping/events/EventHandler.java
+++ b/src/main/java/com/extracraftx/minecraft/bettersleeping/events/EventHandler.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 
 public class EventHandler{
+    private static boolean nightSkipped = false;
+
     public static void onTick(MinecraftServer server){
         int percent = server.getGameRules().getInt(BetterSleeping.key);
         if(percent >= 100 || percent <= 0)
@@ -39,6 +41,7 @@ public class EventHandler{
     }
 
     private static void skipNight(ServerWorld world, List<ServerPlayerEntity> players){
+        nightSkipped = true;
         if(world.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE)){
             long l = world.getLevelProperties().getTimeOfDay() + 24000L;
             world.setTimeOfDay(l - l%24000);
@@ -99,7 +102,11 @@ public class EventHandler{
             return;
         }
         ServerPlayerEntity sp = (ServerPlayerEntity)player;
-        if(count > 0){
+        if(nightSkipped){
+            if(count == 0){
+                nightSkipped = false;
+            }
+        }else{
             sendAsleepMessage(players, count, players.size(), sp.getServer().getGameRules().getInt(BetterSleeping.key));
         }
     }

--- a/src/main/java/com/extracraftx/minecraft/bettersleeping/events/EventHandler.java
+++ b/src/main/java/com/extracraftx/minecraft/bettersleeping/events/EventHandler.java
@@ -99,7 +99,9 @@ public class EventHandler{
             return;
         }
         ServerPlayerEntity sp = (ServerPlayerEntity)player;
-        sendAsleepMessage(players, count, players.size(), sp.getServer().getGameRules().getInt(BetterSleeping.key));
+        if(count > 0){
+            sendAsleepMessage(players, count, players.size(), sp.getServer().getGameRules().getInt(BetterSleeping.key));
+        }
     }
 
     public static void onSleep(PlayerEntity player){


### PR DESCRIPTION
Currently, the mod will send a message like "0/x players are sleeping (0%)" after the "Rise and shine" message. This PR adds a simple check to just not send the message in those cases.